### PR TITLE
Fix getcasinotable Command

### DIFF
--- a/DiamondBlackjack/cl_blackjack.lua
+++ b/DiamondBlackjack/cl_blackjack.lua
@@ -80,14 +80,14 @@ cfg.blackjackTables = {
 --Some maps use the prop vw_prop_casino_blckjack_01 some use vw_prop_casino_blckjack_01b, so change accordingly.
 RegisterCommand("getcasinotable",function()
     local playerCoords = GetEntityCoords(PlayerPedId())
-    local blackjackTable = GetClosestObjectOfType(playerCoords.x,playerCoords.y,playerCoords.z,GetEntityHeading(PlayerPedId()),GetHashKey("vw_prop_casino_blckjack_01"),0,0,0)
+    local blackjackTable = GetClosestObjectOfType(playerCoords.x,playerCoords.y,playerCoords.z,3.0,GetHashKey("vw_prop_casino_blckjack_01"),0,0,0)
     if DoesEntityExist(blackjackTable) then
         print("Found entity")
         print("tablePos pos",GetEntityCoords(blackjackTable))
         print("tableHeading heading",GetEntityHeading(blackjackTable))
         print("prop: vw_prop_casino_blckjack_01")
     else
-        local blackjackTable2 = GetClosestObjectOfType(playerCoords.x,playerCoords.y,playerCoords.z,GetEntityHeading(PlayerPedId()),GetHashKey("vw_prop_casino_blckjack_01b"),0,0,0)
+        local blackjackTable2 = GetClosestObjectOfType(playerCoords.x,playerCoords.y,playerCoords.z,3.0,GetHashKey("vw_prop_casino_blckjack_01b"),0,0,0)
         if DoesEntityExist(blackjackTable2) then
             print("Found entity")
             print("tablePos pos:",GetEntityCoords(blackjackTable2))


### PR DESCRIPTION
Original command used GetEntityHeading(PlayerPedId()) for distance to collect table object within instead of an actual set distance. I pulled the wrong prop information and wasted like 5-10 minutes trying to sort out why I couldn't find the chair I was standing next to.