### PR TITLE
Increase/Decrease Bet Timer and Min Bet Notify

### DIFF
--- a/DiamondBlackjack/cl_blackjack.lua
+++ b/DiamondBlackjack/cl_blackjack.lua
@@ -251,6 +251,7 @@ Citizen.CreateThread(function()
 end)
 
 Citizen.CreateThread(function()
+    local startTime = GetGameTimer()
     while true do 
         if waitingForBetState then
             if IsDisabledControlJustPressed(0, 22) then --Custom Bet [space]
@@ -274,12 +275,16 @@ Citizen.CreateThread(function()
                     notify("~r~Invalid amount.")
                 end
             end
-            if IsControlPressed(0, 10) then --Increase bet [pageup]
+            if IsControlPressed(0, 10) and GetGameTimer()-startTime > 250 then --Increase bet [pageup]
+		startTime = GetGameTimer()
                 currentBetAmount = currentBetAmount + 100
             end            
-            if IsControlPressed(0, 11) then --Decrease bet [pagedown]
+            if IsControlPressed(0, 11) and GetGameTimer()-startTime > 250 then --Decrease bet [pagedown]
                 if currentBetAmount >= 100 then 
+		    startTime = GetGameTimer()
                     currentBetAmount = currentBetAmount - 100
+		else
+		    notify('~r~ Minimum bet reached')
                 end
             end            
         end


### PR DESCRIPTION
Use GetGameTimer() to limit bet increase/decrease to every quarter second instead of every frame, makes it much easier to select desired multiple of 100 without needing to use manual input
Add minimum bet reached notification when trying to go lower than 0